### PR TITLE
feat: usar vector tiles amb MapLibre

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Viewer estàtic de llocs per GitHub Pages.
 
 - Les dades viuen a `places.json`
 - Aquesta web només llegeix i mostra
+- El mapa usa MapLibre GL amb vector tiles (OpenFreeMap style `positron`)
 - Els canvis es fan via commit/PR
 
 ## Esquema mínim (`places.json`)

--- a/app.js
+++ b/app.js
@@ -8,79 +8,135 @@ let places = [];
 let map;
 let markers = [];
 
-function uniq(values){return [...new Set(values.filter(Boolean))].sort((a,b)=>a.localeCompare(b,'ca'))}
+function uniq(values) {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b, 'ca'));
+}
 
-function fillFilters(){
-  for(const c of uniq(places.map(p=>p.city))){
-    const o=document.createElement('option');o.value=c;o.textContent=c;city.appendChild(o);
+function fillFilters() {
+  for (const c of uniq(places.map((p) => p.city))) {
+    const o = document.createElement('option');
+    o.value = c;
+    o.textContent = c;
+    city.appendChild(o);
   }
-  for(const c of uniq(places.map(p=>p.category))){
-    const o=document.createElement('option');o.value=c;o.textContent=c;category.appendChild(o);
+  for (const c of uniq(places.map((p) => p.category))) {
+    const o = document.createElement('option');
+    o.value = c;
+    o.textContent = c;
+    category.appendChild(o);
   }
 }
 
-function matches(p){
-  const text=(q.value||'').trim().toLowerCase();
-  const hay=[p.name,p.city,p.category,(p.tags||[]).join(' '),p.notes||''].join(' ').toLowerCase();
-  if(text && !hay.includes(text)) return false;
-  if(city.value && p.city!==city.value) return false;
-  if(category.value && p.category!==category.value) return false;
+function matches(p) {
+  const text = (q.value || '').trim().toLowerCase();
+  const hay = [p.name, p.city, p.category, (p.tags || []).join(' '), p.notes || ''].join(' ').toLowerCase();
+  if (text && !hay.includes(text)) return false;
+  if (city.value && p.city !== city.value) return false;
+  if (category.value && p.category !== category.value) return false;
   return true;
 }
 
-function card(p){
-  const el=document.createElement('article');
-  el.className='card';
-  el.innerHTML=`
+function card(p) {
+  const el = document.createElement('article');
+  el.className = 'card';
+  el.innerHTML = `
     <h3>${p.name}</h3>
     <div class="meta">${p.city || '-'} · ${p.category || '-'}</div>
     <div class="meta">${p.lat ?? '-'}, ${p.lng ?? '-'}</div>
     <div class="links"><a href="${p.mapsUrl}" target="_blank" rel="noopener">Obrir a Google Maps ↗</a></div>
-    ${p.notes?`<p>${p.notes}</p>`:''}
-    <div class="tags">${(p.tags||[]).map(t=>`<span class="tag">#${t}</span>`).join('')}</div>
+    ${p.notes ? `<p>${p.notes}</p>` : ''}
+    <div class="tags">${(p.tags || []).map((t) => `<span class="tag">#${t}</span>`).join('')}</div>
   `;
   return el;
 }
 
-function initMap(){
-  map = L.map('map').setView([41.9831, 2.8249], 12);
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    maxZoom: 19,
-    attribution: '&copy; OpenStreetMap contributors'
-  }).addTo(map);
+function createPopupHtml(p) {
+  return `
+    <div class="popup">
+      <strong>${p.name}</strong><br>
+      ${p.city || ''}<br>
+      <a href="${p.mapsUrl}" target="_blank" rel="noopener">Google Maps</a>
+    </div>
+  `;
 }
 
-function renderMap(filtered){
-  markers.forEach(m => map.removeLayer(m));
+function clearMarkers() {
+  for (const marker of markers) {
+    marker.remove();
+  }
   markers = [];
+}
 
-  const withCoords = filtered.filter(p => Number.isFinite(p.lat) && Number.isFinite(p.lng));
-  withCoords.forEach(p => {
-    const marker = L.marker([p.lat, p.lng]).addTo(map);
-    marker.bindPopup(`<strong>${p.name}</strong><br>${p.city || ''}<br><a href="${p.mapsUrl}" target="_blank">Google Maps</a>`);
-    markers.push(marker);
+function initMap() {
+  map = new maplibregl.Map({
+    container: 'map',
+    style: 'https://tiles.openfreemap.org/styles/positron',
+    center: [2.8249, 41.9831],
+    zoom: 12,
+    attributionControl: true,
+    antialias: true
   });
 
-  if(withCoords.length){
-    const bounds = L.latLngBounds(withCoords.map(p => [p.lat, p.lng]));
-    map.fitBounds(bounds, { padding: [20,20], maxZoom: 15 });
-  }
+  map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), 'top-right');
+
+  const resize = () => map.resize();
+  window.addEventListener('resize', resize);
 }
 
-function render(){
+function renderMap(filtered) {
+  if (!map) return;
+
+  clearMarkers();
+
+  const withCoords = filtered.filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng));
+  if (!withCoords.length) return;
+
+  for (const p of withCoords) {
+    const popup = new maplibregl.Popup({ offset: 20 }).setHTML(createPopupHtml(p));
+    const marker = new maplibregl.Marker({ color: '#ff7a59' })
+      .setLngLat([p.lng, p.lat])
+      .setPopup(popup)
+      .addTo(map);
+
+    markers.push(marker);
+  }
+
+  if (withCoords.length === 1) {
+    map.easeTo({
+      center: [withCoords[0].lng, withCoords[0].lat],
+      zoom: 14,
+      duration: 700
+    });
+    return;
+  }
+
+  const bounds = new maplibregl.LngLatBounds();
+  for (const p of withCoords) bounds.extend([p.lng, p.lat]);
+
+  map.fitBounds(bounds, {
+    padding: 50,
+    maxZoom: 15,
+    duration: 700
+  });
+}
+
+function render() {
   const filtered = places.filter(matches);
   count.textContent = `${filtered.length} llocs`;
-  list.innerHTML='';
-  filtered.forEach(p=>list.appendChild(card(p)));
+  list.innerHTML = '';
+  filtered.forEach((p) => list.appendChild(card(p)));
   renderMap(filtered);
 }
 
-async function init(){
+async function init() {
   const res = await fetch('places.json');
   places = await res.json();
+
   initMap();
+  map.on('load', () => renderMap(places));
+
   fillFilters();
-  [q, city, category].forEach(el=>el.addEventListener('input', render));
+  [q, city, category].forEach((el) => el.addEventListener('input', render));
   render();
 }
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Rigobertus Map</title>
   <link rel="stylesheet" href="styles.css" />
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  <link href="https://unpkg.com/maplibre-gl@5.3.1/dist/maplibre-gl.css" rel="stylesheet" />
 </head>
 <body>
   <header>
@@ -29,7 +29,7 @@
     <small>Fet amb ❤️ a GitHub Pages</small>
   </footer>
 
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="https://unpkg.com/maplibre-gl@5.3.1/dist/maplibre-gl.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;max-width:10
 header h1{margin:.2rem 0}
 .controls{display:flex;gap:.5rem;flex-wrap:wrap;margin:1rem 0}
 .controls input,.controls select{padding:.6rem;border-radius:.6rem;border:1px solid #2d365c;background:#141b33;color:#e8ecff}
-#map{height:380px;border-radius:.8rem;border:1px solid #2d365c;margin:.6rem 0 1rem 0;overflow:hidden}
+#map{height:420px;border-radius:.9rem;border:1px solid #2d365c;margin:.6rem 0 1rem 0;overflow:hidden;box-shadow:0 10px 26px rgba(0,0,0,.35)}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:.8rem}
 .card{background:#141b33;border:1px solid #2d365c;border-radius:.8rem;padding:.8rem}
 .card h3{margin:.1rem 0 .4rem}
@@ -12,4 +12,8 @@ header h1{margin:.2rem 0}
 .tag{font-size:.75rem;padding:.2rem .45rem;border:1px solid #3c4a78;border-radius:999px;opacity:.9}
 .links a{color:#9fc0ff;text-decoration:none}
 .links a:hover{text-decoration:underline}
+.maplibregl-popup-content{background:#141b33;color:#e8ecff;border:1px solid #2d365c;border-radius:.7rem}
+.maplibregl-popup-tip{border-top-color:#2d365c !important}
+.maplibregl-ctrl-group{border:none !important;border-radius:.6rem !important;overflow:hidden}
+.maplibregl-ctrl button{background:#141b33 !important;color:#e8ecff !important}
 footer{margin:1rem 0;opacity:.7}


### PR DESCRIPTION
## Resum

He migrat el mapa de Leaflet amb raster tiles a **MapLibre GL** amb **vector tiles** per aconseguir un look més modern i una navegació més suau.

## Canvis

- Substitució de Leaflet per MapLibre GL (`maplibre-gl`)
- Basemap vectorial: `https://tiles.openfreemap.org/styles/positron`
- Migració de la lògica de markers/popups i `fitBounds`
- Ajustos visuals del mapa i controls per una sensació més smooth
- Documentació actualitzada al README

## Validació

- Revisió manual del render del mapa i filtres
- Comportament de centrat/zoom per 1 i múltiples resultats

Closes #3
