### PR TITLE
fix(a11y): support prefers-reduced-motion

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,14 @@ let markerById = new Map();
 let pendingPlaceId = null;
 let featuredPlaceId = null;
 
+function prefersReducedMotion() {
+  return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function mapAnimationDuration(defaultDuration = 700) {
+  return prefersReducedMotion() ? 0 : defaultDuration;
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b, 'ca'));
 }
@@ -62,7 +70,7 @@ function highlightPlaceCard(placeId, options = {}) {
   if (!target) return;
 
   if (scroll) {
-    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    target.scrollIntoView({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'center' });
   }
 
   target.classList.add('card-highlight');
@@ -629,7 +637,7 @@ function focusPlace(placeId, options = {}) {
 
   const lngLat = marker.getLngLat();
   if (map && lngLat) {
-    map.easeTo({ center: [lngLat.lng, lngLat.lat], zoom: Math.max(map.getZoom(), 14), duration: 700 });
+    map.easeTo({ center: [lngLat.lng, lngLat.lat], zoom: Math.max(map.getZoom(), 14), duration: mapAnimationDuration(700) });
   }
 
   if (openPopup && marker.getPopup()) {
@@ -690,15 +698,18 @@ function renderMap(filtered) {
   }
 
   if (withCoords.length === 1) {
-    map.easeTo({ center: [withCoords[0].lng, withCoords[0].lat], zoom: 14, duration: 700 });
+    map.easeTo({ center: [withCoords[0].lng, withCoords[0].lat], zoom: 14, duration: mapAnimationDuration(700) });
   } else {
     const bounds = new maplibregl.LngLatBounds();
     for (const p of withCoords) bounds.extend([p.lng, p.lat]);
-    map.fitBounds(bounds, { padding: 50, maxZoom: 15, duration: 700 });
+    map.fitBounds(bounds, { padding: 50, maxZoom: 15, duration: mapAnimationDuration(700) });
   }
 
   if (pendingPlaceId) {
-    setTimeout(() => focusPlace(pendingPlaceId, { openPopup: true, updateUrl: false }), 250);
+    setTimeout(
+      () => focusPlace(pendingPlaceId, { openPopup: true, updateUrl: false }),
+      prefersReducedMotion() ? 0 : 250,
+    );
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,20 @@ select:focus-visible{
   100%{transform:scale(1)}
 }
 
+@media (prefers-reduced-motion: reduce){
+  html:focus-within{scroll-behavior:auto}
+
+  *, *::before, *::after{
+    animation-duration:0.01ms !important;
+    animation-iteration-count:1 !important;
+    transition-duration:0.01ms !important;
+    scroll-behavior:auto !important;
+  }
+
+  .card-highlight{animation:none}
+  .photo-btn:hover img{transform:none;opacity:1}
+}
+
 @media (max-width: 767px){
   body{padding:.75rem}
   .controls{position:sticky;top:0;z-index:10;background:#0b1020;padding:.6rem 0 .4rem;gap:.6rem}


### PR DESCRIPTION
## Summary
- add a dedicated prefers-reduced-motion helper in app.js
- disable smooth card scroll and set map animation durations to 0 when reduced motion is preferred
- add @media (prefers-reduced-motion: reduce) CSS overrides to minimize transitions/animations

## Validation
- node --check app.js
- manual review of reduced-motion code paths for scrollIntoView, easeTo, and fitBounds

Fixes #19