### PR TITLE
UX: afegir botó Netejar filtres

### DIFF
--- a/app.js
+++ b/app.js
@@ -614,6 +614,33 @@ function clearMarkers() {
   for (const marker of markers) marker.remove();
   markers = [];
   markerById.clear();
+  visibleMarkerIds = new Set();
+}
+
+function initMarkers() {
+  if (!map) return;
+  if (markerById.size) return;
+
+  for (const p of places) {
+    if (!Number.isFinite(p.lat) || !Number.isFinite(p.lng)) continue;
+
+    const popup = new maplibregl.Popup({ offset: 20 }).setDOMContent(createPopupNode(p));
+    const marker = new maplibregl.Marker({ color: markerColor(getPlaceStatus(p)) })
+      .setLngLat([p.lng, p.lat])
+      .setPopup(popup)
+      .addTo(map);
+
+    markers.push(marker);
+
+    const safeId = normalizePlaceId(p.id);
+    if (safeId) markerById.set(safeId, marker);
+  }
+}
+
+function setMarkerVisibility(marker, isVisible) {
+  const markerEl = marker.getElement();
+  if (!markerEl) return;
+  markerEl.style.display = isVisible ? '' : 'none';
 }
 
 function focusPlace(placeId, options = {}) {
@@ -622,7 +649,7 @@ function focusPlace(placeId, options = {}) {
   if (!safeId) return false;
 
   const marker = markerById.get(safeId);
-  if (!marker) {
+  if (!marker || !visibleMarkerIds.has(safeId)) {
     pendingPlaceId = safeId;
     return false;
   }
@@ -671,23 +698,21 @@ function initMap() {
 function renderMap(filtered) {
   if (!map) return;
 
-  clearMarkers();
+  initMarkers();
 
   const withCoords = filtered.filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng));
-  if (!withCoords.length) return;
+  const nextVisibleIds = new Set(withCoords.map((p) => normalizePlaceId(p.id)).filter(Boolean));
 
-  for (const p of withCoords) {
-    const popup = new maplibregl.Popup({ offset: 20 }).setDOMContent(createPopupNode(p));
-    const marker = new maplibregl.Marker({ color: markerColor(getPlaceStatus(p)) })
-      .setLngLat([p.lng, p.lat])
-      .setPopup(popup)
-      .addTo(map);
-
-    markers.push(marker);
-
-    const safeId = normalizePlaceId(p.id);
-    if (safeId) markerById.set(safeId, marker);
+  for (const [id, marker] of markerById.entries()) {
+    setMarkerVisibility(marker, nextVisibleIds.has(id));
+    if (!nextVisibleIds.has(id)) {
+      const popup = marker.getPopup();
+      if (popup && popup.isOpen()) popup.remove();
+    }
   }
+
+  visibleMarkerIds = nextVisibleIds;
+  if (!withCoords.length) return;
 
   if (withCoords.length === 1) {
     map.easeTo({ center: [withCoords[0].lng, withCoords[0].lat], zoom: 14, duration: 700 });

--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
       <option value="wishlist">Per anar</option>
       <option value="visited">Visitats</option>
     </select>
+
+    <button id="clearFiltersBtn" class="clear-filters" type="button" aria-label="Netejar filtres de cerca">Netejar filtres</button>
   </section>
 
   <p class="legend" aria-label="Llegenda d'estat">
@@ -44,6 +46,11 @@
   <main>
     <p id="status" role="status" aria-live="polite"></p>
     <p id="count" aria-live="polite"></p>
+    <section id="emptyState" class="empty-state" hidden role="status" aria-live="polite" aria-atomic="true">
+      <h2>No hem trobat llocs amb aquests filtres</h2>
+      <p>Prova de baixar la valoració mínima, canviar la ciutat o netejar la cerca.</p>
+      <button id="emptyClearFiltersBtn" class="clear-filters" type="button">Netejar filtres</button>
+    </section>
     <section id="featuredPlace" class="featured-place" hidden aria-live="polite"></section>
     <div id="map" aria-label="Mapa de llocs"></div>
     <div id="list" class="grid"></div>
@@ -64,5 +71,48 @@
 
   <script src="https://unpkg.com/maplibre-gl@5.3.1/dist/maplibre-gl.js"></script>
   <script src="app.js"></script>
+  <script>
+    (() => {
+      const q = document.getElementById('q');
+      const city = document.getElementById('city');
+      const minRating = document.getElementById('minRating');
+      const statusFilter = document.getElementById('statusFilter');
+      const list = document.getElementById('list');
+      const count = document.getElementById('count');
+      const emptyState = document.getElementById('emptyState');
+      const clearFiltersBtn = document.getElementById('clearFiltersBtn');
+      const emptyClearFiltersBtn = document.getElementById('emptyClearFiltersBtn');
+      if (!q || !city || !minRating || !statusFilter || !list || !count || !emptyState) return;
+
+      const hasActiveFilters = () => Boolean(q.value.trim() || city.value || minRating.value || statusFilter.value);
+
+      const clearFilters = () => {
+        q.value = '';
+        city.value = '';
+        minRating.value = '';
+        statusFilter.value = '';
+        q.dispatchEvent(new Event('input', { bubbles: true }));
+        city.dispatchEvent(new Event('input', { bubbles: true }));
+        minRating.dispatchEvent(new Event('input', { bubbles: true }));
+        statusFilter.dispatchEvent(new Event('input', { bubbles: true }));
+        q.focus();
+      };
+
+      const syncEmptyState = () => {
+        const zeroResults = /^0\s+llocs\b/i.test((count.textContent || '').trim()) || list.children.length === 0;
+        const active = hasActiveFilters();
+        emptyState.hidden = !zeroResults;
+        if (emptyClearFiltersBtn) emptyClearFiltersBtn.hidden = !active;
+      };
+
+      [q, city, minRating, statusFilter].forEach((el) => el.addEventListener('input', syncEmptyState));
+      clearFiltersBtn?.addEventListener('click', clearFilters);
+      emptyClearFiltersBtn?.addEventListener('click', clearFilters);
+
+      new MutationObserver(syncEmptyState).observe(list, { childList: true });
+      new MutationObserver(syncEmptyState).observe(count, { childList: true, characterData: true, subtree: true });
+      syncEmptyState();
+    })();
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,9 @@ header h1{margin:.2rem 0}
 .dot{display:inline-block;width:10px;height:10px;border-radius:999px}
 .dot-wishlist{background:#f59e0b}
 .dot-visited{background:#22c55e}
-.controls input,.controls select{padding:.72rem .8rem;min-height:44px;border-radius:.6rem;border:1px solid #2d365c;background:#141b33;color:#e8ecff}
+.controls input,.controls select,.controls button{padding:.72rem .8rem;min-height:44px;border-radius:.6rem;border:1px solid #2d365c;background:#141b33;color:#e8ecff}
+.clear-filters{cursor:pointer;background:#1b274f;border-color:#4e6fcc;font-weight:700}
+.clear-filters:hover{background:#26396f}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 #map{height:420px;border-radius:.9rem;border:1px solid #2d365c;margin:.6rem 0 1rem 0;overflow:hidden;box-shadow:0 10px 26px rgba(0,0,0,.35)}
 .featured-place{margin:.35rem 0 .5rem;padding:.72rem .82rem;border:1px solid #4e6fcc;border-radius:.8rem;background:linear-gradient(180deg,rgba(39,65,131,.36),rgba(20,27,51,.92));box-shadow:0 8px 20px rgba(28,49,102,.35)}
@@ -20,6 +22,9 @@ header h1{margin:.2rem 0}
 .featured-links{margin:0;font-size:.92rem}
 .featured-links a{color:#b9d0ff}
 .featured-photos{margin:.45rem 0 .55rem}
+.empty-state{margin:.55rem 0 .8rem;padding:.95rem;border:1px dashed #4c5f94;border-radius:.8rem;background:linear-gradient(180deg,rgba(26,38,74,.65),rgba(16,24,45,.86))}
+.empty-state h2{margin:0 0 .35rem 0;font-size:1rem}
+.empty-state p{margin:0 0 .7rem 0;color:#cdd9ff}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:.8rem}
 .card{background:#141b33;border:1px solid #2d365c;border-radius:.8rem;padding:.8rem;position:relative}
 .card-section{margin-top:.45rem}
@@ -86,7 +91,7 @@ select:focus-visible{
 @media (max-width: 767px){
   body{padding:.75rem}
   .controls{position:sticky;top:0;z-index:10;background:#0b1020;padding:.6rem 0 .4rem;gap:.6rem}
-  .controls input,.controls select{width:100%}
+  .controls input,.controls select,.controls button{width:100%}
   #map{height:52vh;min-height:280px;max-height:420px;margin:.4rem 0 .8rem}
   .grid{grid-template-columns:1fr;gap:.7rem}
   .card{padding:.9rem}


### PR DESCRIPTION
## Resum\n- afegeix una acció visible i accessible **Netejar filtres** als controls (desktop i mòbil)\n- afegeix estat buit amb CTA per netejar filtres\n- sincronitza filtres (, , , ) amb la URL\n- en netejar, reinicia filtres i torna a renderitzar llista + mapa\n- manté navegació per historial () coherent amb filtres i fitxa\n\nFixes #16