### PR TITLE
Fix card selection interactions and keyboard support

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,6 +77,17 @@ function highlightPlaceCard(placeId, options = {}) {
   setTimeout(() => target.classList.remove('card-highlight'), 1400);
 }
 
+function syncSelectedCardState() {
+  const selectedId = normalizePlaceId(featuredPlaceId);
+  const cards = list ? list.querySelectorAll('.card[data-place-id]') : [];
+
+  cards.forEach((cardEl) => {
+    const isSelected = selectedId && cardEl.dataset.placeId === selectedId;
+    cardEl.classList.toggle('card-selected', Boolean(isSelected));
+    cardEl.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+  });
+}
+
 function safeHttpUrl(value) {
   if (!value) return '#';
   try {
@@ -321,6 +332,7 @@ function clearSelectedPlace(options = {}) {
   }
 
   renderFeaturedPlace();
+  syncSelectedCardState();
   setStatus('');
 }
 
@@ -472,7 +484,12 @@ function card(p) {
   const el = document.createElement('article');
   el.className = 'card';
   const safeId = normalizePlaceId(p.id);
-  if (safeId) el.id = `place-${safeId}`;
+  if (safeId) {
+    el.id = `place-${safeId}`;
+    el.dataset.placeId = safeId;
+    el.tabIndex = 0;
+    el.setAttribute('aria-selected', normalizePlaceId(featuredPlaceId) === safeId ? 'true' : 'false');
+  }
 
   const status = getPlaceStatus(p);
 
@@ -548,6 +565,27 @@ function card(p) {
     }
   }
   el.appendChild(tags);
+
+  if (safeId) {
+    const shouldIgnoreCardActivation = (event) => {
+      const interactive = event.target instanceof Element
+        ? event.target.closest('a, button, input, select, textarea, summary, [role="button"]')
+        : null;
+      return Boolean(interactive && el.contains(interactive));
+    };
+
+    el.addEventListener('click', (event) => {
+      if (shouldIgnoreCardActivation(event)) return;
+      focusPlace(safeId, { openPopup: true, scrollToCard: false });
+    });
+
+    el.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      if (shouldIgnoreCardActivation(event)) return;
+      event.preventDefault();
+      focusPlace(safeId, { openPopup: true, scrollToCard: false });
+    });
+  }
 
   return el;
 }
@@ -651,6 +689,7 @@ function focusPlace(placeId, options = {}) {
 
   featuredPlaceId = safeId;
   renderFeaturedPlace();
+  syncSelectedCardState();
   highlightPlaceCard(safeId, { scroll: scrollToCard });
 
   const place = places.find((item) => normalizePlaceId(item.id) === safeId);
@@ -727,6 +766,7 @@ function render() {
   count.textContent = `${filtered.length} llocs`;
   list.innerHTML = '';
   filtered.forEach((p) => list.appendChild(card(p)));
+  syncSelectedCardState();
   renderFeaturedPlace();
   renderMap(filtered);
 }

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,7 @@ header h1{margin:.2rem 0}
 .card-empty{opacity:.7;font-style:italic}
 .card-notes{margin:0;color:#dbe3ff}
 .card-highlight{outline:3px solid #7aa2ff;outline-offset:2px;transition:outline-color .2s ease;animation:cardPulse 1.2s ease}
+.card-selected{border-color:#7aa2ff;box-shadow:0 0 0 2px rgba(122,162,255,.25),0 8px 24px rgba(34,56,120,.35)}
 .card-top{display:flex;align-items:flex-start;justify-content:space-between;gap:.6rem;margin:.05rem 0 .5rem}
 .card h3{margin:0;font-size:1.06rem;line-height:1.25}
 .status-badge{display:inline-flex;align-items:center;gap:.35rem;font-size:.75rem;font-weight:800;letter-spacing:.02em;padding:.28rem .58rem;border-radius:999px;border:1px solid transparent;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,.2)}


### PR DESCRIPTION
## Summary
- make each place card activatable by click and keyboard (Enter/Space) to run `focusPlace`
- ignore clicks/keypresses coming from inner interactive controls (`a`, `button`, etc.) so links/buttons keep their existing behavior
- keep a persistent visual selected-card state synced with the currently focused/featured place

## Validation
- `node --check app.js`
- quick manual behavior checks in code path: card activation now routes through `focusPlace` and selected state is synced on focus, clear, and render

Fixes pilipilisbot/rigobertus-map#17
