### PR TITLE
Define canonical restaurant card contract and normalize status catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Mapa estàtic de llocs recomanats per publicar a GitHub Pages.
 ]
 ```
 
+## Contracte canònic de fitxa
+
+Veure `docs/cards-spec.md` per la definició oficial de:
+
+- camps obligatoris i opcionals
+- catàleg d'estats vàlids (`wishlist | visited`)
+- ordre visual de la targeta
+- regles de consistència i validació
+
 ## Validació local de dades
 
 Abans de pujar canvis a `places.json`, valida'ls en local:

--- a/docs/cards-spec.md
+++ b/docs/cards-spec.md
@@ -1,0 +1,77 @@
+# Contracte canònic de fitxa de restaurant
+
+Aquest document defineix el contracte de dades + presentació per a cada targeta renderitzada des de `places.json`.
+
+## Objectiu
+
+- Tenir un catàleg de camps clar i estable
+- Evitar estats i continguts inconsistents
+- Facilitar validació automàtica abans de publicar
+
+## Catàleg de camps
+
+### Camps obligatoris (targeta funcional)
+
+- `id` (`string`, slug únic)
+- `name` (`string`)
+- `lat` (`number|null`)
+- `lng` (`number|null`)
+- `city` (`string`)
+- `category` (`"restaurant"|"bar"`)
+- `tags` (`string[]`, pot ser buit)
+- `mapsUrl` (`string`, URL)
+- `status` (`"wishlist"|"visited"`)
+- `externalRating` (`number`, `0..5`)
+- `externalReviewCount` (`integer`, `>=0`)
+
+### Camps opcionals controlats
+
+- `rigobertusRating` (`number|null`, `0..5`)
+- `visitedAt` (`YYYY-MM-DD`)
+- `notes` (`string`)
+- `photos` (`string[]`)
+- `placeId` (`string`)
+- `website` (`string`, URL)
+- `planned` (`boolean`)
+
+## Estats vàlids
+
+Només es permeten aquests valors:
+
+- `wishlist` → lloc pendent de visita
+- `visited` → lloc visitat
+
+> `pending` queda **retirat** i s’ha de migrar a `wishlist`.
+
+## Contracte visual (ordre de blocs de targeta)
+
+Ordre canònic de render a UI:
+
+1. Títol (`name`) + badge d’estat (`status`)
+2. Ciutat (`city`)
+3. Bloc de valoració:
+   - `rigobertusRating` si existeix i el lloc és `visited`
+   - si no, missatge de pendent
+   - `externalRating` + `externalReviewCount` com a referència
+4. Visita (`visitedAt` si existeix; altrament `—`)
+5. Fotos (`photos`) o placeholder
+6. Enllaços (Maps + compartir fitxa)
+7. Notes (`notes`) o placeholder
+8. Tags (`tags`) o placeholder
+
+## Regles de consistència pràctiques
+
+- `id` ha de ser únic a tot `places.json`
+- `lat/lng` han de ser dos números vàlids o tots dos `null`
+- valoracions (`externalRating`, `rigobertusRating`) sempre dins `0..5`
+- no admetre estats fora del catàleg (`wishlist|visited`)
+
+## Validació
+
+La validació s’executa amb:
+
+```bash
+npm run validate:places
+```
+
+Inclou schema JSON i comprovacions addicionals (`id` duplicat, rangs i coordenades).

--- a/places.json
+++ b/places.json
@@ -564,7 +564,7 @@
       "pendent"
     ],
     "mapsUrl": "https://maps.google.com/?q=41.9853588,2.8187121",
-    "status": "pending",
+    "status": "wishlist",
     "photos": [],
     "placeId": "ChIJpQJ0ucDnuhIR7fxvJxwfdms",
     "lat": 41.9853588,
@@ -582,7 +582,7 @@
       "pendent"
     ],
     "mapsUrl": "https://maps.google.com/?q=41.9136307,3.1538627",
-    "status": "pending",
+    "status": "wishlist",
     "photos": [],
     "placeId": "ChIJDQOacyNVuhIRQn7b-KEIPnU",
     "lat": 41.9136307,
@@ -601,7 +601,7 @@
       "txuleton"
     ],
     "mapsUrl": "https://maps.google.com/?q=41.9641382,2.8632119",
-    "status": "pending",
+    "status": "wishlist",
     "photos": [],
     "placeId": "ChIJCdqlTwfkuhIRDJohAHCPXPM",
     "lat": 41.9641382,

--- a/schema/places.schema.json
+++ b/schema/places.schema.json
@@ -33,7 +33,7 @@
       },
       "mapsUrl": { "type": "string", "format": "uri" },
       "notes": { "type": "string" },
-      "status": { "type": "string", "enum": ["wishlist", "visited", "pending"] },
+      "status": { "type": "string", "enum": ["wishlist", "visited"] },
       "planned": { "type": "boolean" },
       "visitedAt": { "type": "string", "format": "date" },
       "placeId": { "type": "string", "minLength": 1 },


### PR DESCRIPTION
## Summary
- add `docs/cards-spec.md` as the canonical restaurant card contract (required/optional fields, valid statuses, and visual order)
- link the new contract from `README.md`
- align validation catalog by restricting `status` to `wishlist|visited` in JSON Schema
- migrate existing `pending` entries in `places.json` to `wishlist`

## Validation
- `npm run validate:places`

Fixes pilipilisbot/rigobertus-map#24