### PR TITLE
docs: editorial governance + PR checklist for places data

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Resum
+
+<!-- Explica breument què canvia i per què -->
+
+## Tipus de canvi
+
+- [ ] Alta de nou lloc
+- [ ] Actualització d'un lloc existent
+- [ ] Correcció de dades (coordenades, URL, tags, etc.)
+- [ ] Només documentació
+
+## Checklist de dades (`places.json`)
+
+- [ ] He revisat la guia editorial: `docs/editorial-governance.md`
+- [ ] Les dades noves/modificades estan en català (quan aplica)
+- [ ] Les dates segueixen el format `YYYY-MM-DD`
+- [ ] `tags` en minúscula, sense duplicats, entre 1 i 5
+- [ ] `notes` neutrals i ≤ 240 caràcters
+- [ ] Els camps mínims requerits hi són presents
+- [ ] He executat `npm run validate:places` i passa correctament
+
+## Evidència (opcional)
+
+<!-- Enganxa sortida de validació, captures o enllaços útils -->

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ La validació comprova:
 
 A CI també s'executa automàticament a cada PR amb `.github/workflows/validate-places.yml`.
 
+## Governança editorial i canvis de dades
+
+- Guia editorial + checklist per noves entrades: [`docs/editorial-governance.md`](docs/editorial-governance.md)
+- Plantilla de PR reutilitzable per canvis de dades: [`.github/pull_request_template.md`](.github/pull_request_template.md)
+
 ## Publicació
 
 La workflow `.github/workflows/pages.yml` desplega automàticament a GitHub Pages quan fas push a `main`.

--- a/docs/editorial-governance.md
+++ b/docs/editorial-governance.md
@@ -1,0 +1,42 @@
+# Guia editorial i checklist de noves entrades
+
+Aquesta guia defineix criteris mínims per mantenir `places.json` coherent, útil i fàcil de revisar.
+
+## Normes editorials (resum)
+
+- **Idioma principal:** català (`ca`) a `name`, `city`, `tags` i `notes` (quan no sigui nom propi).
+- **Format de data:** `YYYY-MM-DD` (per exemple `2026-03-21`) a camps com `visitedAt`.
+- **To de les notes:** clar, descriptiu i neutral (evitar insults, exageracions o text promocional).
+- **Longitud de notes:** màxim **240 caràcters**.
+- **Tags recomanats:**
+  - usa tags curts en minúscula i `kebab-case` (ex. `barri-vell`, `baix-emporda`)
+  - entre **1 i 5 tags** per entrada
+  - evitar duplicats, sinònims redundants i tags massa genèrics
+
+## Camps mínims per acceptar una nova entrada
+
+Abans d'acceptar una nova entrada, ha de tenir com a mínim:
+
+- `id` únic (slug en minúscula i amb guions)
+- `name`
+- `lat` i `lng`
+- `city`
+- `category` (`restaurant` o `bar`)
+- `tags` (1..5)
+- `mapsUrl`
+- `status` (`wishlist`, `visited` o `pending`)
+- `externalRating`
+- `externalReviewCount`
+
+> Important: qualsevol camp opcional afegit ha de respectar l'esquema JSON i no trencar `npm run validate:places`.
+
+## Checklist ràpid per afegir un lloc
+
+- [ ] L'entrada compleix els **camps mínims obligatoris**
+- [ ] L'`id` és únic i en format slug (`kebab-case`)
+- [ ] Coordenades i URL de mapes verificades
+- [ ] Textos en català (excepte noms propis)
+- [ ] Dates en format `YYYY-MM-DD`
+- [ ] `notes` neutrals i ≤ 240 caràcters
+- [ ] `tags` en minúscula, sense duplicats, entre 1 i 5
+- [ ] Validació local executada: `npm run validate:places`


### PR DESCRIPTION
## Summary
- add a concise editorial governance guide for new places in `docs/editorial-governance.md`
- define acceptance checklist: Catalan as primary language, `YYYY-MM-DD` date format, tags rules/limits, note tone and max length, and minimum required fields
- add reusable PR template checklist for `places.json` changes in `.github/pull_request_template.md`
- link both docs from README

## Validation
- `npm run validate:places`

Fixes pilipilisbot/rigobertus-map#28
