### PR TITLE
feat(seo): add WebSite JSON-LD structured data

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ Si el `website-id` és placeholder, els events queden en no-op i la web funciona
 - Mantén igualment política de privacitat i avís legal.
 - No enviïs dades personals als events.
 
+## Structured data (SEO)
+
+- El projecte publica JSON-LD tipus `WebSite` a `index.html`.
+- L’`ItemList` queda pendent per una fase posterior, quan definim millor una estratègia de llistes/pàgines indexables per evitar marcatge poc estable.
+
 ## Publicació
 
 La workflow `.github/workflows/pages.yml` desplega automàticament a GitHub Pages quan fas push a `main`.

--- a/index.html
+++ b/index.html
@@ -18,6 +18,22 @@
   <meta name="twitter:description" content="Mapa interactiu de restaurants recomanats a Girona, amb filtres per ciutat, valoració i estat." />
   <meta name="twitter:image" content="https://rigobertus.cat/og-default.jpg" />
 
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Rigobertus Map",
+    "url": "https://rigobertus.cat/",
+    "inLanguage": "ca",
+    "description": "Mapa interactiu de restaurants recomanats a Girona, amb filtres per ciutat, valoració i estat.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://rigobertus.cat/?q={search_term_string}",
+      "query-input": "required name=search_term_string"
+    }
+  }
+  </script>
+
   <link rel="stylesheet" href="styles.css" />
   <link href="https://unpkg.com/maplibre-gl@5.3.1/dist/maplibre-gl.css" rel="stylesheet" />
 </head>


### PR DESCRIPTION
## Summary
- adds Schema.org JSON-LD of type WebSite in `index.html`
- includes SearchAction aligned with `?q=` search param
- documents current structured data scope in README

## Decision
- implemented WebSite now (stable and low risk)
- deferred ItemList until list/indexation strategy is defined, to avoid unstable or misleading markup

Closes #48
